### PR TITLE
Corretti typo lezioni di Tantati di Meccanica statistica

### DIFF
--- a/Lezioni/lezione18-11-21.tex
+++ b/Lezioni/lezione18-11-21.tex
@@ -120,7 +120,7 @@
 Tale teorema stabilisce che un sistema dinamico misurabile può essere ergodico rispetto a due misure "che non si parlano". Ci sono tuttavia dei sistemi dinamici che ammettono una sola misura invariante. In tale caso si dà la seguente definizione.
 
 \begin{definition}[sistema unicamente ergodico]
-    $ (X; \mathcal{A}, \mu, f) $ si dice unicamente ergodico se esiste un'unica misura di probabilità su $ (X; \mathcal{A}) $ che sia $ f $-invariante.
+    $ (X, \mathcal{A}, \mu, f) $ si dice unicamente ergodico se esiste un'unica misura di probabilità su $ (X, \mathcal{A}) $ che sia $ f $-invariante.
 \end{definition}
 
 Tale definizione è ben posta perché un sistema unicamente ergodico è anche ergodico. Se infatti per assurdo $ (X, \mathcal{A}, \mu, f) $ non fosse ergodico esisterebbe $ A \in \mathcal{A} $ $ f $-invariante tale che $ \mu(A) > 0 $ e $ \mu(X \setminus A) > 0 $. Possiamo allora definire le misure

--- a/Lezioni/lezione18-12-12.tex
+++ b/Lezioni/lezione18-12-12.tex
@@ -5,16 +5,22 @@
 
 \subsection{Formalismo della meccanica statistica}
 Sia $ (\Sigma, \P(\Sigma), P) $ uno spazio di probabilità, dove $ \Sigma $ è finito. Ogni elemento $ \sigma $ di $ \Sigma $ descrive un possibile stato del sistema.
-Nel seguito, con lieve abuso di notazione, scriveremo $ P(\sigma) $ intendendo $ P(\{\sigma\}) $.
+Essendo lo spazio per l'appunto di dimensione finita, le sa $ \sigma $-algebra l'insieme delle parti, è sufficiente definire la misura di probabilità sui $ \sigma \in \Sigma $ per determinare $ P $ su ogni sottoinsieme di $ \sigma $.  Nel seguito quindi, con lieve abuso di notazione, scriveremo $ P(\sigma) $ intendendo $ P(\{\sigma\}) $. \\
 Se il sistema viene descritto da una funzione \emph{hamiltoniana} $ \ham \colon \Sigma\to\R $ si introduce solitamente una misura di probabilità su $ \Sigma $, detta \emph{misura di Boltzmann}, data da
-\[ P_\beta(\sigma) \coloneqq \frac{1}{Z_\beta} e^{-\beta\ham(\sigma)} \]
+\begin{equation}
+    P_\beta(\sigma) \coloneqq \frac{1}{Z_\beta} e^{-\beta\ham(\sigma)}
+\end{equation}
 dove è stata introdotta la \emph{funzione di partizione} del sistema
-\[ Z_\beta \coloneqq \sum_{\sigma\in\Sigma} e^{-\beta \ham(\sigma)}. \]
+\begin{equation}
+    Z_\beta \coloneqq \sum_{\sigma\in\Sigma} e^{-\beta \ham(\sigma)}.
+\end{equation}
 Muniti di questa misura possiamo esprimere il valor medio di una generica osservabile $ \mathcal{O}\colon \Sigma\to\R $ su tutti gli stati possibili:
-\[ \langle\mathcal{O}\rangle = \sum_{\sigma\in\Sigma} P_\beta(\sigma)\mathcal{O}(\sigma). \]
-\textcolor{red}{L'idea è che all'equilibrio (cioè quando le medie temporali delle osservabili del sistema non dipendono dal tempo) tale media coincida con la media temporale della stessa osservabile}.
+\begin{equation} \label{eqn:media-osservabile}
+    \langle\mathcal{O}\rangle = \sum_{\sigma\in\Sigma} P_\beta(\sigma)\mathcal{O}(\sigma).
+\end{equation}
+Uno degli assunti fondamentali della meccanica statistica è che sullo spazio $ (\Sigma, \P(\Sigma), P) $ sia definita una qualche dinamica misurabile e che il sistema dinamico risultante sia \emph{ergodico}. A questo punto ci si dimentica dell'esistenza di una dinamica e si utilizza direttamente la misura invariante $ P $ per studiare il comportamento del sistema all'equilibrio. Per ergodicità, le medie temporali degli osservabili lungo la dinamica coincidono quindi con il valore atteso delle osservabili stesse rispetto alla misura $ P $, cioè coincidono con l'espressione nell'equazione \eqref{eqn:media-osservabile} \\
 
-Posto $ \Sigma = \{-1,1\}^N $ e dette $ \sigma_i $ le componenti di ciascuno stato $ \sigma $ ($ \sigma_i $ è lo stato di una delle $ N $ particelle del sistema nella configurazione $ \sigma $), osserviamo preliminarmente che:
+Un sistema a $ N $ corpi con \emph{spin} è descritto da uno spazio degli stati $ \Sigma = \{-1,1\}^N $ dove $ \sigma_i \in \{-1\, 1\} $ sono le componenti di ciascuno stato $ \sigma $ ($ \sigma_i $ è lo stato di una delle $ N $ particelle del sistema nella configurazione $ \sigma $). Osserviamo preliminarmente che:
 \begin{itemize}
     \item se l'hamiltoniana ha la forma $ \ham(\sigma) = \sum_{i=1}^{N} \ham_i(\sigma_i) $, la misura di Boltzmann si fattorizza nel prodotto di $ N $ termini ognuno dei quali dipende da una sola $ \sigma_i $, dunque questa hamiltoniana modellizza un sistema i cui elementi non interagiscono tra loro;
     \item se si aggiungono termini di interazione fra gli elementi (tutti o solo alcuni) si avrà un'hamiltoniana della forma:
@@ -37,21 +43,32 @@ Introduciamo l'\emph{energia libera}
     F_\beta \coloneqq -\frac{1}{\beta} \log{Z_\beta},
 \end{equation}
 l'\emph{energia interna}
-\[ U \coloneqq \langle\ham\rangle = \sum_{\sigma\in\Sigma} P(\sigma)\ham(\sigma) \]
+\begin{equation}
+    U[P] \coloneqq \langle\ham\rangle = \sum_{\sigma\in\Sigma} P(\sigma)\ham(\sigma)
+\end{equation}
 e il funzionale \emph{entropia}
-\[ S[P] = -\sum_{\sigma\in\Sigma} P(\sigma) \log{P(\sigma)}. \]
+\begin{equation}
+    S[P] \coloneqq -\sum_{\sigma\in\Sigma} P(\sigma) \log{P(\sigma)}.
+\end{equation}
 Calcoliamo ora l'entropia della misura di Boltzmann:
 \[ S[P_\beta] = - \sum_{\sigma\in\Sigma} \frac{1}{Z_\beta}e^{-\beta\ham(\sigma)} \left( -\log{Z_\beta}  - \beta\ham(\sigma) \right) = \log{Z_\beta} + \beta U_\beta \]
-da cui, usando la \eqref{eq:en_libera}
-\[ F_\beta = U_\beta - \frac{1}{\beta} S[P_\beta]. \]
-Si verificano inoltre le seguenti relazioni:
-\[ U_\beta = \pd{\beta F_\beta}{\beta} \qquad S_\beta = \beta^2 \pd{F_\beta}{\beta} \]
+da cui, usando la \eqref{eq:en_libera}, si ottiene
+\begin{equation} \label{eqn:gibbs-boltzmann}
+    F_\beta = U_\beta - \frac{1}{\beta} S[P_\beta].
+\end{equation}
+\begin{equation}
+    U_\beta = \pd{\beta F_\beta}{\beta} \qquad S_\beta = \beta^2 \pd{F_\beta}{\beta}
+\end{equation}
 
 \subsection{Energia libera di Gibbs e principi variazionali}
 Con lo spirito di generalizzare la \eqref{eq:en_libera}, introduciamo il funzionale \emph{energia libera di Gibbs} per una misura di probabilità generica:
-\[ G[P] \coloneqq U - \frac{1}{\beta} S[P] = \sum_{\sigma\in\Sigma} P(\sigma)\ham(\sigma) + \frac{1}{\beta}\sum_{\sigma\in\Sigma} P(\sigma) \log{P(\sigma)}. \]
-Ovviamente si ha $ G[P_\beta] = F_\beta $. Vogliamo ora analizzare se $ G[P_\beta] $ sia un estremo dell'energia libera di Gibbs. A tale scopo introduciamo la \emph{divergenza di Kullback-Leibler}
-\[ D(P_1 \parallel P_2) \coloneqq \sum_{\sigma\in\Sigma} P_1(\sigma) \log{\frac{P_1(\sigma)}{P_2(\sigma)}}. \]
+\begin{equation}
+    G[P] \coloneqq U[P] - \frac{1}{\beta} S[P] = \sum_{\sigma\in\Sigma} P(\sigma)\ham(\sigma) + \frac{1}{\beta}\sum_{\sigma\in\Sigma} P(\sigma) \log{P(\sigma)}.
+\end{equation}
+Ovviamente per l'equazione \eqref{eqn:gibbs-boltzmann} si ha $ G[P_\beta] = F_\beta $. Vogliamo ora analizzare se $ G[P_\beta] $ sia un estremo dell'energia libera di Gibbs. A tale scopo introduciamo la \emph{divergenza di Kullback-Leibler}
+\begin{equation}
+    D(P_1 \parallel P_2) \coloneqq \sum_{\sigma\in\Sigma} P_1(\sigma) \log{\frac{P_1(\sigma)}{P_2(\sigma)}}.
+\end{equation}
 Si verifica che
 \begin{itemize}
     \item $ D(P_1 \parallel P_2) $ è convessa in $ P_1 $;
@@ -59,20 +76,30 @@ Si verifica che
     \item $ D(P_1 \parallel P_2) $ non è simmetrica nei suoi argomenti.
 \end{itemize}
 Infine si ha che, per una generica $ P $:
-\[ G[P] = G[P_\beta] + \frac{1}{\beta} D(P \parallel P_\beta) \]
-da cui segue che $ G[P] $ ha un minimo (globale) quando $ P = P_\beta $ e, poiché dalla convessità di $ D $ segue che $ G[P] $ è convesso in $ P $, non esistono altri estremi del funzionale.
+\begin{align*}
+	G[P] & = \sum_{\sigma\in\Sigma} P(\sigma)\ham(\sigma) + \frac{1}{\beta}\sum_{\sigma\in\Sigma} P(\sigma) \log{\left(\frac{P(\sigma)}{P_\beta(\sigma)} P_\beta(\sigma)\right)}                \\
+	     & = \sum_{\sigma\in\Sigma} P(\sigma)\ham(\sigma) + \frac{1}{\beta}\sum_{\sigma\in\Sigma} P(\sigma) \log{P_\beta(\sigma)} + D(P \parallel P_\beta)                                      \\
+	     & = \sum_{\sigma\in\Sigma} P(\sigma)\ham(\sigma) + \frac{1}{\beta}\sum_{\sigma\in\Sigma} P(\sigma) \log{\left(\frac{e^{-\beta \ham(\sigma)}}{Z_\beta}\right)} + D(P \parallel P_\beta) \\
+	     & = \sum_{\sigma\in\Sigma} P(\sigma)\ham(\sigma) - \sum_{\sigma\in\Sigma} P(\sigma)\ham(\sigma) - \frac{1}{\beta} Z_\beta \sum_{\sigma\in\Sigma} P(\sigma) + D(P \parallel P_\beta)    \\
+	     & = -\frac{1}{\beta} Z_\beta + D(P \parallel P_\beta)
+\end{align*}
+ovvero
+\begin{equation}
+     G[P] = G[P_\beta] + \frac{1}{\beta} D(P \parallel P_\beta)
+\end{equation}
+Pertanto otteniamo che $ G[P] $ ha un minimo (globale) quando $ P = P_\beta $ e, poiché dalla convessità di $ D $ segue che $ G[P] $ è convesso in $ P $, non esistono altri estremi del funzionale. \\
 
 Vogliamo ora riscrivere il principio variazionale così individuato (cioè che la misura di Boltzmann è l'unica che minimizza l'energia libera di Gibbs) in termini di un altro principio variazionale che coinvolga l'entropia. Abbiamo che, detto $ \mathcal{P} $ l'insieme delle possibili misure di probabilità su $ \Sigma $:
 \begin{align*}
     P_\beta(\sigma) = \argmin_{P\in\mathcal{P}} G[P] & = \argmin_{P\in\mathcal{P}} \left[ \sum_{\sigma\in\Sigma} P(\sigma) \ham(\sigma) - \frac{1}{\beta} S[P] \right]\\
                                                      & = \argmax_{P\in\mathcal{P}} \left[ S[P] - \beta \sum_{\sigma\in\Sigma}P(\sigma)\ham(\sigma) \right]\\
-                                                     & = \argmax_{\substack{P\in\mathcal{P}\\ U=\bar{U}}} S[P].
+                                                     & = \argmax_{\substack{P\in\mathcal{P}\\ U=\overline{U}}} S[P].
 \end{align*}
-Nell'ultimo passaggio si è interpretato $ \beta $ come un moltiplicatore di Lagrange, e dunque il problema di massimo in analisi può essere visto come un problema di massimo della sola entropia, col vincolo di mantenere l'energia interna fissata a una certa costante $ \bar{U} $.
+Nell'ultimo passaggio si è interpretato $ \beta $ come un moltiplicatore di Lagrange, e dunque il problema di massimo in analisi può essere visto come un problema di massimo della sola entropia, col vincolo di mantenere l'energia interna fissata a una certa costante $ \overline{U} $.
 
-Verifichiamo ora esplicitamente che la misura di Boltzmann è quella che massimizza l'entropia a fissata energia interna. Introduciamo due moltiplicatori di Lagrange per fissare il vincolo che l'energia interna sia pari a $ \bar{U} $ e che la generica misura $ P\in\mathcal{M} $ sia di probabilità, cioè $ \sum_{\sigma\in\Sigma}P(\sigma) = 1 $.
+Verifichiamo ora esplicitamente che la misura di Boltzmann è quella che massimizza l'entropia a fissata energia interna. Introduciamo due moltiplicatori di Lagrange per fissare il vincolo che l'energia interna sia pari a $ \overline{U} $ e che la generica misura $ P\in\mathcal{M} $ sia di probabilità, cioè $ \sum_{\sigma\in\Sigma}P(\sigma) = 1 $.
 \begin{align*}
-    \argmax_{\substack{P\in\mathcal{P}\\ U=\bar{U}}} S[P] & = \argmax_{\substack{P\in\mathcal{P}\\ U=\bar{U}}} \left[ -\sum_{\sigma\in\Sigma}P(\sigma)\log{P(\sigma)} \right]\\
+    \argmax_{\substack{P\in\mathcal{P}\\ U=\overline{U}}} S[P] & = \argmax_{\substack{P\in\mathcal{P}\\ U=\overline{U}}} \left[ -\sum_{\sigma\in\Sigma}P(\sigma)\log{P(\sigma)} \right]\\
                                                           & = \argmax_{P\in\mathcal{M}} \left[ -\sum_{\sigma\in\Sigma}P(\sigma)\log{P(\sigma)} - \beta \sum_{\sigma\in\Sigma}P(\sigma)\ham(\sigma) + \lambda \sum_{\sigma\in\Sigma}P(\sigma) \right]
 \end{align*}
 Detto $ p_i \coloneqq P(\sigma^i) $, dove $ \sigma^i \in \Sigma $ è una delle possibili configurazioni, ed essendo $ \Sigma $ finito, possiamo identificare $ \mathcal{M} $ con $ \R^N $, con $ N \coloneqq \card(\Sigma) $. L'argomento dell'$ \argmax $ può quindi essere pensato come una funzione $ f\colon \R^{N+2}\to\R $ così definita
@@ -81,9 +108,9 @@ Dobbiamo quindi imporre che le derivate parziali $ \pd{f}{p_j} $ si annullino
 \[ \lambda -1 - \log{p_j} - \beta \ham(\sigma^j) = 0 \]
 da cui
 \[ p_j = e^{\lambda - 1} e^{-\beta\ham(\sigma^j)}. \]
-Dobbiamo ora imporre i vincoli; scegliamo $ \lambda $ in modo tale che $ \sum_{i=1}^{N} p_i = 1 $, cioè $ {e^{\lambda - 1} = 1/Z_\beta} $. Imponiamo infine:
-\[ \sum_{i=1}^{N} \frac{1}{Z_\beta} e^{-\beta\ham(\sigma^i)} \ham(\sigma^i) = \bar{U} \]
-Da cui si ottiene $ \beta $ in funzione di $ \bar{U} $, ma per i nostri scopi conviene lasciare la dipendenza esplicita da $ \beta $. Otteniamo quindi, come atteso,
+Dobbiamo ora imporre i vincoli. Scegliamo $ \lambda $ in modo tale che $ \sum_{i=1}^{N} p_i = 1 $, cioè $ {e^{\lambda - 1} = 1/Z_\beta} $. Imponiamo infine:
+\[ \sum_{i=1}^{N} \frac{1}{Z_\beta} e^{-\beta\ham(\sigma^i)} \ham(\sigma^i) = \overline{U} \]
+Da cui si ottiene $ \beta $ in funzione di $ \overline{U} $, ma per i nostri scopi conviene lasciare la dipendenza esplicita da $ \beta $. Otteniamo quindi, come atteso,
 \[ P(\sigma^j) = \frac{1}{Z_\beta} e^{-\beta\ham{\sigma^j}}. \]
 
 \subsection{Esercizi}

--- a/Lezioni/lezione18-12-19.tex
+++ b/Lezioni/lezione18-12-19.tex
@@ -3,18 +3,35 @@
 \subsection{Entropia di Shannon}
 Claude Shannon: \emph{A Mathematical Theory of Communication}, 1948. \\
 
-Sia $ (X, \mathcal{A}, \mu) $ uno spazio di probabilità e consideriamo una partizione finita dello spazio \linebreak $ X = A_1 \sqcup \ldots \sqcup A_n \pmod{0} $ cioè tale che gli insiemi $ A_i $ sono a due a due disgiunti a meno di insiemi di misura nulla e la loro unione è $ X $ a meno di un insieme di misura nulla. Sia $ p_i \coloneqq \mu(A_i) $ che definisce un vettore di probabilità $ p \coloneqq (p_1, \ldots, p_n) \in \R^n_+ $ essendo $ \sum_{i = 1}^{n} p_i = 1 $. Indichiamo con $ \Delta^{(n)} \coloneqq \{(p_1, \ldots, p_n) \in \R^n_+ : \sum_{i=0}^{n} p_i\} $ lo spazio dei vettori di probabilità in $ \R^n $.
+Sia $ (X, \mathcal{A}, \mu) $ uno spazio di probabilità e consideriamo una partizione finita dello spazio \linebreak $ X = A_1 \sqcup \ldots \sqcup A_n \pmod{0} $ cioè tale che gli insiemi $ A_i $ sono a due a due disgiunti a meno di insiemi di misura nulla e la loro unione è $ X $ a meno di un insieme di misura nulla. A tale partizione possiamo associare un vettore di probabilità $ p \coloneqq (p_1, \ldots, p_n) \in \R^n_+ $ dove $ p_i \coloneqq \mu(A_i) $. Indichiamo con $ \Delta^{(n)} \coloneqq \{(p_1, \ldots, p_n) \in \R^n_+ : \sum_{i=0}^{n} p_i=1\} $ lo spazio dei vettori di probabilità in $ \R^n $. \\
+
+L'idea di Shannon è quella di associare a ogni elemento $ x \in X $ una certa quantità di \emph{informazione} $ I(x) $ partendo dal fatto che gli eventi più rari contengono informazione maggiore. La seconda intuizione di Shannon è di utilizzare la scala logaritmica per quantificare tale informazione: se $ x \in A_i $ della partizione allora $ I(x) = -\log p_i $. In tale modo se $ x $ un evento è ``raro'', ovvero $ p_i=\mu(A_i) $ è ``piccola'', allora $ I(x) $ sarà ``grande''; viceversa se $ x $ è un evento frequente, ovvero $ p_i $ è ``grande'', allora $ I(x) $ sarà ``piccola''. Più formalmente definiamo la funzione che indica l'indice della partizione a cui $ x $ appartiene\footnote{Siccome la partizione è definita $ (\mathrm{mod} 0) $ chiaramente $ i $ sarà una funzione definita quasi ovunque.}
+\begin{align*}
+    i \colon X & \to \{1, \ldots, n\} \\
+    x & \mapsto i(x) = j : x \in A_{j}
+\end{align*}
+da cui la funzione \emph{informazione} è
+\begin{align*}
+    I \colon X & \to [0, +\infty) \\
+    x & \mapsto -\log p_{i(x)}
+\end{align*}
+L'\emph{entropia di Shannon} della partizione è una quantità che ci dice qual è l'informazione media contenuta nella partizione, ovvero sarà il valore di aspettazione della funzione informazione
+\begin{equation} \label{eqn:entropia-shannon}
+    H \coloneqq \mathbb{E}[I] = \int_{X} I(x) \dif{\mu(x)} = -\sum_{i=1}^{n} p_i \log{p_i}
+\end{equation}
+
+Il seguente teorema formalizza le nozioni di informazione media sopra esposte e afferma che la definizione di entropia dell'equazione \eqref{eqn:entropia-shannon} è l'unica compatibile (a meno di riscalamenti) con una serie di assiomi che corrispondo a nozioni intuitive legate all'idea di informazione media data a Shannon.
 
 \begin{thm}[entropia di Shannon]
     Sia $ H^{(n)} \colon \Delta^{(n)} \to [0, +\infty) $ una funzione reale sullo spazio dei vettori di probabilità che chiamiamo entropia. Supponiamo che:    \begin{enumerate}[label=(\roman*)]
-        \item $ H^{(n)} $ sia continua e non identicamente costante;
+        \item\label{pt:continua} $ H^{(n)} $ sia continua e non identicamente costante;
         \item $ H^{(n)} $ sia simmetrica nei suoi argomenti;
         \item $ H^{(n)}(1, 0, \ldots, 0) = 0 $;
-        \item le entropie sono "concatenate": $ H^{(n)}(0, p_2, \ldots, p_n) = H^{(n-1)}(p_2, \ldots, p_n) $;
-        \item l'entropia massima è quella "più casuale": $ H^{(n)}(p_1, \ldots, p_n) \leq H^{(n)}\left(\dfrac{1}{n}, \ldots, \dfrac{1}{n}\right) $;
-        \item l'entropia una partizione in $ n \cdot l $ insiemi è l'entropia degli $ n $ raggruppamenti della partizione in $ l $ insiemi più la media pesata delle "entropie relative" all'interno di ciascun raggruppamento, calcolate con la probabilità condizionata. In formule
+        \item\label{pt:concat} le entropie sono ``concatenate'': $ H^{(n)}(0, p_2, \ldots, p_n) = H^{(n-1)}(p_2, \ldots, p_n) $;
+        \item\label{pt:max} l'entropia massima è quella ``più casuale'': $ H^{(n)}(p_1, \ldots, p_n) \leq H^{(n)}\left(\dfrac{1}{n}, \ldots, \dfrac{1}{n}\right) $;
+        \item\label{pt:formula} l'entropia di una partizione in $ n \cdot l $ insiemi è l'entropia degli $ n $ raggruppamenti della partizione in $ l $ insiemi più la media pesata delle ``entropie relative'' all'interno di ciascun raggruppamento, calcolate con la probabilità condizionata. In formule
         \[
-            H^{(nl)}(\pi_{11}, \ldots, \pi_{1l}, \ldots, \pi_{n1}, \ldots, \pi_{nl}) = H^{(n)}(p_1, \ldots, p_n) + \sum_{i = 0}^{n} p_i \, H^{(l)} \left(\dfrac{\pi_{i1}}{p_i}, \ldots, \dfrac{\pi_{il}}{p_i}\right)
+            H^{(nl)}(\pi_{11}, \ldots, \pi_{1l}, \ldots, \pi_{n1}, \ldots, \pi_{nl}) = H^{(n)}(p_1, \ldots, p_n) + \sum_{i=1}^{n} p_i \, H^{(l)} \left(\dfrac{\pi_{i1}}{p_i}, \ldots, \dfrac{\pi_{il}}{p_i}\right)
         \]
         dove $ p_i \coloneqq \sum_{j = 1}^{l} \pi_{ij} $.
     \end{enumerate}
@@ -25,10 +42,43 @@ Sia $ (X, \mathcal{A}, \mu) $ uno spazio di probabilità e consideriamo una part
     e viene detta entropia di Shannon.
 \end{thm}
 \begin{proof}
-    Per prima cosa mostreremo che la tesi vale per $ K(n) \coloneqq H^{(n)}\left(\frac{1}{n}, \ldots, \frac{1}{n}\right) $. Useremo l'ultima proprietà per trovare l'espressione di $ H^{(n)} $ sui razionali e concluderemo così per densità. \textcolor{red}{Mancante}
+    Per prima cosa mostreremo che la tesi vale per $ K(n) \coloneqq H^{(n)}\left(\frac{1}{n}, \ldots, \frac{1}{n}\right) = C \cdot \log{n} $. Useremo l'ultima proprietà per trovare l'espressione di $ H^{(n)} $ sui razionali e concluderemo così per densità. \\
+    Dalla \ref{pt:concat} e dalla \ref{pt:max} otteniamo che $ K(n) $ è una funzione non decrescente in $ n $
+    \[
+        K(n+1) = H^{(n+1)}\left(\frac{1}{n+1}, \ldots, \frac{1}{n+1}\right) \geq H^{(n+1)}\left(0, \frac{1}{n}, \ldots, \frac{1}{n}\right) = H^{(n)}\left(\frac{1}{n}, \ldots, \frac{1}{n}\right) = K(n).
+    \]
+    Mentre dalla \ref{pt:concat} abbiamo che $ K(nl) = K(n) + K(l) $: infatti prendendo $ \pi_{ij} = \frac{1}{nl} $ da cui $ p_i = \sum_{j=1}^{l} \frac{1}{nl} = \frac{1}{n} $ si ottiene
+    \begin{align*}
+        K(nl) & = H^{(nl)}\left(\frac{1}{nl}, \ldots, \frac{1}{nl}\right) = H^{(n)}\left(\frac{1}{n}, \ldots, \frac{1}{n}\right) + \sum_{i=1}^{n} \frac{1}{n} H^{(l)} \left(\frac{1}{l}, \ldots, \frac{1}{l}\right) \\
+        & = K(n) + n\frac{1}{n} K(l)
+    \end{align*}
+    Ora $ \forall r, l \in \N\setminus\{0\} $ e $ \forall n \in \N $, sia $ m \in \N $ tale che $ l^{m} \leq r^{n} \leq l^{m+1} $. Per quanto detto sulla funzione $ K $ abbiamo che $ K(l^m) \leq K(r^{n}) \leq K(l^{m+1}) $ ovvero
+    \[ \frac{m}{n} \leq \frac{K(r)}{K(l)} \leq \frac{m}{n} + \frac{1}{n}. \]
+    Se applichiamo il logaritmo alla stessa disuguaglianza otteniamo similmente
+    \[ \frac{m}{n} \leq \frac{\log{r}}{\log{l}} \leq \frac{m}{n} + \frac{1}{n} \]
+    da cui
+    \[ \frac{K(r)}{K(l)} - \frac{1}{n} \leq \frac{\log{r}}{\log{l}} \leq \frac{K(r)}{K(l)} + \frac{1}{n}. \]
+    Passando al limite in $ n $ otteniamo che $ \forall r, l \in \N\setminus\{0\} $ vale $ \frac{K(r)}{K(l)} = \frac{\log{r}}{\log{l}} $ da cui esiste una costante $ C > 0 $ tale che $ K(r) = C \cdot \log{r} $. \\
+    Ora per la \ref{pt:concat} e la \ref{pt:formula}
+    \begin{align*}
+        H^{\left(\sum_{i=1}^{n} l_i\right)}(\pi_{11},\ldots,\pi_{1l_1}
+        , \ldots, \pi_{n1},\ldots,\pi_{1l_n}) & = H^{(nL)}(\pi_{11}, \ldots, \pi_{1L}, \ldots, \pi_{n1}, \ldots, \pi_{nL}) \\
+        & = H^{(n)}(p_1, \ldots, p_n) + \sum_{i=1}^{n} p_i \, H^{(L)} \left(\dfrac{\pi_{i1}}{p_i}, \ldots, \dfrac{\pi_{iL}}{p_i}\right) \\
+        & = H^{(n)}(p_1, \ldots, p_n) + \sum_{i=1}^{n} p_i \, H^{(l_i)} \left(\dfrac{\pi_{i1}}{p_i}, \ldots, \dfrac{\pi_{il_i}}{p_i}\right)
+    \end{align*}
+    dove $ L \coloneqq \max\{l_1, \ldots, l_n\} $ e abbiamo posto a zero le probabilità $ \pi_{i (l_j+1)}, \ldots, \pi_{jL} $. Se ora poniamo $ s\coloneqq\sum_{i=1}^{n}l_i $ e prendiamo $ \pi_{ij} = 1/s $ otteniamo che $ p_i = l_i/s $ così
+    \[ K(s) = H^{(s)}\left(\frac{1}{s}. \ldots, \frac{1}{s}\right) = H^{(n)}\left(\frac{l_1}{s}, \ldots, \frac{l_n}{s}\right) + \sum_{i=1}^{n} \frac{l_i}{s} H^{(l_i)}\left(\frac{1}{l_i}, \ldots, \frac{1}{l_i}\right) \]
+    ovvero
+    \begin{align*}
+        H^{(n)}\left(\frac{l_1}{s}, \ldots, \frac{l_n}{s}\right) = K(s) - \sum_{i=1}^{n} \frac{l_i}{s} K(l_i) = C \log{s} \cdot \sum_{i=1}^{n} \frac{l_i}{s} - C \sum_{i=1}^{n} \frac{l_i}{s} \log{\frac{1}{l_i}} = - C \sum_{i=1}^{n}\frac{l_i}{s} \log{\frac{l_i}{s}}.
+    \end{align*}
+    Tale espressione determina $ H^{(n)} $ su tutti i vettori di probabilità a componenti razionali. Infatti se $ \left(\frac{r_1}{s_1},\ldots,\frac{r_n}{s_n}\right) \in \Delta^{(n)} $ con $ l_i, s_i \in \N $, posto $ s \coloneqq \mathrm{mcm}\{s_1, \ldots, s_n\} $ e $ l_i = r_i \frac{s}{s_i} $ si ha $ \left(\frac{r_1}{s_1},\ldots,\frac{r_n}{s_n}\right) = \left(\frac{l_1}{s}, \ldots, \frac{l_n}{s}\right) $ e inoltre $ \sum_{i=1}^{n} l_i = s $ essendo $ \sum_{i=1}^{n}\frac{r_i}{s_i} $. Così
+    \[ H^{(n)}\left(\frac{r_1}{s_1},\ldots,\frac{r_n}{s_n}\right) = H^{(n)}\left(\frac{l_1}{s}, \ldots, \frac{l_n}{s}\right) = - C \sum_{i=1}^{n}\frac{l_i}{s} \log{\frac{l_i}{s}} = - C \sum_{i=1}^{n}\frac{r_i}{s_i} \log{\frac{r_i}{s_i}}. \]
+    Dobbiamo ora mostrare che tale formula si estende in modo unico anche ai vettori di probabilità reali. La funzione $ f_n(p_1, \ldots, p_n) = -C\sum_{i=1}^{n}p_i \log{p_i} $ definita su tutto $ \Delta^{(n)} $\footnote{In realtà $ f_n $ è l'estensione continua di $ -C\sum_{i=1}^{n}p_i \log{p_i} $ che è ben definita solo sui vettori di probabilità con componenti tutte non nulle.} è una funzione continua su un compatto e pertanto uniformemente continua. D'altra parte abbiamo visto che $ f_n $ coincide con $ H^{(n)} $ su $ \Delta^{(n)} \cap \Q^{n} $ ed $ H^{(n)} $ la restrizione di $ f_n $ ai vettori di probabilità razionali è uniformemente continua sul suo domino. Così per la \ref{pt:continua}, la funzione $ H^{(n)} $ si estende in modo unico alla chiusura di $ \Delta^{(n)} \cap \Q^{n} $ che è $ \Delta^{(n)} $ e, per unicità dell'estensione, tale estensione deve coincidere con $ f_n $ su tutto $ \Delta^{(n)} $.
 \end{proof}
 
-Data una partizione $ \mathcal{P} \coloneqq \{A_1, \ldots, A_n\} $ di $ X \pmod{0} $ scriveremo più brevemente $ H(\mathcal{P}) \coloneqq H^{(n)}(\mu(A_1). \ldots, \mu(A_n)) $.
+Data una partizione $ \mathcal{P} \coloneqq \{A_1, \ldots, A_n\} $ di $ X \pmod{0} $ scriveremo più brevemente
+\[ H(\mathcal{P}) \coloneqq H^{(n)}(\mu(A_1), \ldots, \mu(A_n)). \]
 
 \subsection{Entropia metrica o di Kolmogorov-Sinai}
 

--- a/Lezioni/lezione18-12-19.tex
+++ b/Lezioni/lezione18-12-19.tex
@@ -22,7 +22,7 @@ L'\emph{entropia di Shannon} della partizione è una quantità che ci dice qual 
 
 Il seguente teorema formalizza le nozioni di informazione media sopra esposte e afferma che la definizione di entropia dell'equazione \eqref{eqn:entropia-shannon} è l'unica compatibile (a meno di riscalamenti) con una serie di assiomi che corrispondo a nozioni intuitive legate all'idea di informazione media data a Shannon.
 
-\begin{thm}[entropia di Shannon]
+\begin{thm}[entropia di Shannon] \label{thm:Shannon}
     Sia $ H^{(n)} \colon \Delta^{(n)} \to [0, +\infty) $ una funzione reale sullo spazio dei vettori di probabilità che chiamiamo entropia. Supponiamo che:    \begin{enumerate}[label=(\roman*)]
         \item\label{pt:continua} $ H^{(n)} $ sia continua e non identicamente costante;
         \item $ H^{(n)} $ sia simmetrica nei suoi argomenti;
@@ -82,26 +82,32 @@ Data una partizione $ \mathcal{P} \coloneqq \{A_1, \ldots, A_n\} $ di $ X \pmod{
 
 \subsection{Entropia metrica o di Kolmogorov-Sinai}
 
-\begin{definition}[raffinamento di due partizioni]
-    Se $ \mathcal{P} \coloneqq \{A_1, \ldots, A_n\} $ e $ \mathcal{Q} \coloneqq \{B_1, \ldots, B_m\} $ sono due partizioni di $ X \pmod{0} $ si definisce il raffinamento di $ \mathcal{P} $ e $ \mathcal{Q} $ la partizione
+\begin{definition}[join di due partizioni]
+    Se $ \mathcal{P} \coloneqq \{A_1, \ldots, A_n\} $ e $ \mathcal{Q} \coloneqq \{B_1, \ldots, B_m\} $ sono due partizioni di $ X \pmod{0} $ si definisce il join di $ \mathcal{P} $ e $ \mathcal{Q} $ come la partizione
     \[
         \mathcal{P} \vee \mathcal{Q} \coloneqq \{A_i \cap B_j : i = 1, \ldots, n \text{ e } j = 1, \ldots, m\}.
     \]
 \end{definition}
 
-Dato un sistema dinamico misurabile $ (X, \mathcal{A}, \mu, f) $ possiamo considerare il raffinamento delle iterazioni di $ f $ su $ \mathcal{P} $. Posto $ f^{-k}\mathcal{P} \coloneqq \{f^{-k}(A_i) : A_i \in \mathcal{P}\} $ sia
+Dato un sistema dinamico misurabile $ (X, \mathcal{A}, \mu, f) $ possiamo considerare il join delle iterazioni di $ f $ su $ \mathcal{P} $. Posto $ f^{-k}\mathcal{P} \coloneqq \{f^{-k}(A_i) : A_i \in \mathcal{P}\} $ tale join è
 \[
-    \mathcal{P}^{(n)} \coloneqq \mathcal{P} \vee (f^{-1}\mathcal{P}) \vee \cdots \vee (f^{-(n-1)}\mathcal{P}).
+    \mathcal{P}^{(n)} \coloneqq \mathcal{P} \vee (f^{-1}\mathcal{P}) \vee \cdots \vee (f^{-(n-1)}\mathcal{P}) = \bigvee_{i=0}^{n}f^{-i}\mathcal{P}
 \]
+
+Tale costruzione ha lo scopo di quantificare l'informazione media che si ottiene facendo la \emph{dinamica simbolica} dell'iterazione di $ f $ usando la partizione $ \mathcal{P} $. Alla partizione $ \mathcal{P} = \{A_1, \ldots, A_n\} $ associamo l'insieme di simboli $ \{a_1, \ldots, a_n\} $. Consideriamo l'orbita di un punto $ x \in X $ sotto l'azione di $ f $: al passo $ n $-esimo dell'iterazione codifichiamo il blocco della partizione in cui sta $ f^{n}(x) $ con il simbolo $ a_{i_n} $ associato alla partizione, e così per ogni $ n \in \N $. In tale modo all'orbita corrisponde una successione $ (a_{i_n}) $ che è la codifica dell'orbita data dalla scelta della partizione.
+
+Ora se $ B \in \mathcal{P}^{(n)} $ vuol dire che $ B = A_{i_0} \cap f^{-1}(A_{i_1}) \cap \cdots \cap f^{-(n-1)}(A_{i_{n-1}}) $ ovvero se $ x \in B $ vuol dire che $ x \in A_{i_0}, f(x) \in A_{i_1}, \ldots, f^{n-1}(x) \in A_{i_{n-1}} $. Pertanto a $ B \in \mathcal{P}^{(n)} $ corrisponde l'insieme degli $ x \in X $ che hanno come dinamica simbolica fino all'$ n $-esima iterazione la stringa $ (a_{i_0}, \ldots, a_{i_{n-1}}) $.
+
+Pertanto $ H(\mathcal{P}^{(n)}) $ quantifica, in un certo senso, l'informazione media che si ottiene sulla dinamica di $ f $ conoscendo i primi $ n $ blocchi in cui è ``passata'' l'orbita di un elemento di $ X $ sotto $ f $. Dividendo tale quantità per $ n $ (la lunghezza della stringa della dinamica simbolica) e prendendo il limite in $ n $ otteniamo quindi l'informazione media che si ottiene sulla dinamica di $ f $ facendo la dinamica simbolica usando come partizione dello spazio $ \mathcal{P} $. Chiaramente tale limite dipende dalla partizione scelta, che poteva per esempio non essere ottimale per la codifica di $ f $: per definire un'entropia associata al sistema dinamico $ (X, \mathcal{A}, \mu, f) $ dovremo quindi prendere l'estremo superiore di tale limite al variare della partizione.
 
 \begin{definition}[entropia di Kolmogorov-Sinai]
     Sia $ (X, \mathcal{A}, \mu, f) $ un sistema dinamico misurabile. L'entropia del sistema è
     \[
         h_\mu(f) \coloneqq \sup_\mathcal{P} {\lim_{n \to +\infty} \frac{1}{n}H(\mathcal{P}^{(n)})}
     \]
-    dove l'estremo superiore è fatto al variare di $ \mathcal{P} $ partizione finita (o numerabile) di $ X \pmod{0} $.
+    dove $ H $ è l'entropia di Shannon della partizione e l'estremo superiore è fatto al variare di $ \mathcal{P} $ partizione finita (o numerabile) di $ X \pmod{0} $.
 \end{definition}
-Questa è una buona definizione in quanto il limite di cui si fa il $ \sup $ esiste in virtù del seguente
+Per mostrare che questa è una buona definizione enunciamo il seguente
 \begin{lemma}[Fekete] \label{lem:fekete}
     Se $ a \colon \N\setminus\{0\} \to \R $ è una successione subadditiva (cioè tale che $ a_{n+m} \leq a_n + a_m $) allora esiste
     \[
@@ -114,6 +120,23 @@ Questa è una buona definizione in quanto il limite di cui si fa il $ \sup $ esi
     dove $ \bar{r} = \argmax_{r\in\{ 0,\ldots, \bar{n}-1 \}} a_r $. Prendendo il $ \limsup $ si ha
     \[ \limsup_{n\to\infty} \frac{a_n}{n} \leq \frac{a_{\bar{n}}}{\bar{n}} \leq \alpha + \epsilon \]
     da cui, per l'arbitrarietà di $ \epsilon $, si conclude.
+\end{proof}
+Grazie a tale lemma ci basta allora dimostrare che la successione $ H(\mathcal{P}^{(n)}) $ è subadditiva in $ n $. Ora
+\[ H(\mathcal{P}^{(n+m)}) = H\left(\bigvee_{i=0}^{n+m}f^{-i}\mathcal{P}\right) = H\left(P^{(m)} \vee \bigvee_{i=m+1}^{n+m}f^{-i}\mathcal{P}\right) \]
+e d'altra parte
+\[ H\left(\bigvee_{i=n+1}^{n+m}f^{-i}\mathcal{P}\right) = H\left(f^{-m}\bigvee_{i=1}^{n}f^{-i}\mathcal{P}\right) = H\left(\bigvee_{i=1}^{n}f^{-i}\mathcal{P}\right) = H(\mathcal{P}^{(n)}) \]
+in quanto per $ f $-invarianza della misura, se $ \bigvee_{i=1}^{n}f^{-i}\mathcal{P} = \{B_1, \ldots, B_k\} $ allora $ f^{-m}\bigvee_{i=1}^{n}f^{-i}\mathcal{P} = \{f^{-m}(B_1), \ldots, f^{-m}(B_k)\} $ così $ \mu(f^{-m}(B_i)) = \mu(B_i) $ è l'entropia di Shannon delle due partizioni è la stessa. Per concludere ci basta basta quindi mostrare la seguente
+
+\begin{proposition}
+    Date due partizioni $ \mathcal{P} $ e $ \mathcal{Q} $ vale $ H(\mathcal{P} \vee \mathcal{Q}) \leq H(\mathcal{P}) + H(\mathcal{Q}) $.
+\end{proposition}
+\begin{proof}
+    Siano $ \mathcal{P} = \{A_1, \ldots, A_n\} $ e $ \mathcal{Q} = \{B_1, \ldots, B_m\} $. Allora per il teorema \ref{thm:Shannon}, punto \ref{pt:formula} abbiamo che
+    \[ H(\mathcal{P} \vee \mathcal{Q}) = H(\mathcal{P}) + \sum_{i, j} p_i f(t_{ij}) \]
+    dove $ p_i = \mu(A_i) $ e $ t_{ij} = \frac{\mu(A_i \cap B_j)}{\mu(A_i)} $ e $ f(x) = - x \log{x} $. Essendo $ f $ convessa e $ \sum_{i} p_i = 1 $ otteniamo per la disuguaglianza di Jensen
+    \[ \sum_{i} p_i f(t_{ij}) \leq f\left(\sum_{i} p_i t_{ij}\right) = f(\mu(B_j)) = - \mu(B_j) \log{\mu(B_j)} \]
+    così
+    \[ \sum_{ij} p_j f(t_{ij}) = \sum_{j} \sum_{i} p_j f(t_{ij}) \leq - \sum_{j} \mu(B_j) \log{\mu(B_j)} = H(\mathcal{Q}). \qedhere \]
 \end{proof}
 
 \begin{exercise}

--- a/Lezioni/lezione19-01-16.tex
+++ b/Lezioni/lezione19-01-16.tex
@@ -1,35 +1,44 @@
 \section{Lezione del 16/01/19 [Tantari]}
 \textcolor{red}{Introduzione e road map vanno riviste quando avrò finito la seconda lezione e sarà chiaro (spero) cosa si sta cercando di fare.}
 
-Ci prefiggiamo di studiare ora il modello di Curie-Weiss nel \emph{limite termodinamico}, cioè nel limite in cui il numero $ n $ di particelle tende a infinito. In particolare calcoleremo il limite dell'energia libera $ f_{\beta, n} \coloneqq F_{\beta, n}/n = -\frac{\log Z_{\beta, n}}{\beta n}$\footnote{D'ora in poi ometteremo il pedice $ \beta $ per alleggerire la notazione.}.
+Ci prefiggiamo di studiare ora il modello di Curie-Weiss nel \emph{limite termodinamico}, cioè nel limite in cui il numero $ n $ di particelle tende a infinito.
+
+In linea di principio, potremmo voler calcolare direttamente il limite della distribuzione di Boltzmann $ \lim_{n \to \infty} P_{\beta, n} $. Tuttavia tale limite conduce a problematiche assolutamente non banali: per esempio le $ P_{\beta, n} $ sono definite su spazi di misura diversi la cui cardinalità cresce con $ n $ e pertanto non è ben chiaro che cosa voglia dire fare tale limite\footnote{Una trattazione di che cosa voglia dire il limite termodinamico della misura di Boltzmann è stato fatto da Dobrushin, Lanford e Ruelle e porta alla definizione degli \emph{stati DLR}.}. Pertanto il limite termodinamico viene di solito formulato in termini di quantità termodinamiche che sono numeri reali. In particolare calcoleremo il limite dell'energia libera $ f_{\beta, n} \coloneqq F_{\beta, n}/n = -\frac{\log Z_{\beta, n}}{\beta n}$\footnote{D'ora in poi ometteremo il pedice $ \beta $ per alleggerire la notazione.}.
 
 \subsubsection{Road map}
 \begin{enumerate}
   \item Calcolo di $ \lim_{n\to\infty} \frac{1}{n} \log{Z_n} = \lim_{n\to\infty} -\frac{\beta F_n}{n} $
-  \item Data una generica osservabile $ \mathcal{O}\colon\Sigma\to\R $, calcoliamone il valore atteso nel limite termodinamico $ \lim_{n\to\infty} \mean{\mathcal{O}_n(\sigma)}_{P_\beta} $. Nel nostro caso considereremo la \emph{magnetizzazione media} $ m_n(\sigma) \coloneqq \mean{\frac{1}{n}\sum_{i=1}^{n}\sigma_i}_{P_\beta} $.
+  \item Data una generica osservabile $ \mathcal{O}\colon\Sigma\to\R $, calcoliamone il valore atteso nel limite termodinamico $ \lim_{n\to\infty} \mean{\mathcal{O}_n(\sigma)}_{P_{\beta, n}} $. Nel nostro caso considereremo la \emph{magnetizzazione media} $ m_n(\sigma) \coloneqq \frac{1}{n}\sum_{i=1}^{n}\sigma_i $.
   \item \textcolor{red}{Automedia: calcolo delle fluttuazioni delle osservabili}.
   $ \lim_{n\to\infty} P_\beta\left(\ \abs{m_n(\sigma) - m_\beta } > \epsilon \right) $.
   \textcolor{red}{Non capisco cosa sia $ m_\beta $ e se quella che prima ho definito come $ m_n $ sia davvero $ m_n $ oppure sia $ m_\beta $.}
 \end{enumerate}
 
 Nel modello di Curie-Weiss lo spazio delle fasi è $ \Sigma = \{-1,1\}^n $. L'hamiltoniana è:
-\[ \ham_n(\sigma) = -\frac{1}{n} \sum_{i<j} \sigma_i \sigma_j - h \sum_i \sigma_i \]
-dove il primo termine descrive l'interazione tra gli spin, che tendono ad allinearsi, e il secondo l'interazione con il campo esterno $ h $. Osserviamo che $ \ham_n $ scala come $ n $; una quantità di questo tipo di dice \emph{intensiva}. La quantità che ci prefiggiamo di calcolare, $ f_n $, è invece \emph{intensiva}.
+\begin{equation}
+    \ham_n(\sigma) = -\frac{1}{n} \sum_{i<j} \sigma_i \sigma_j - h \sum_i \sigma_i
+\end{equation}
+dove il primo termine descrive l'interazione tra gli spin, che tendono ad allinearsi, e il secondo l'interazione con il campo esterno $ h $. Osserviamo che $ \sum_{i=1}^{n} \sigma_i $ scala come $ n $, $ \sum_{i<j} \sigma_i \sigma_j $ scala come $ n^2 $  e pertanto $ \ham_n $ scala come $ n $; una quantità di questo tipo di dice \emph{estensiva}. La quantità che ci prefiggiamo di calcolare, $ f_n $, è invece \emph{intensiva}.
 
-Cominciamo riscrivendo l'hamiltoniana in termini di $ m_n(\sigma) $:
+Cominciamo riscrivendo l'hamiltoniana in termini della magnetizzazione media $ m_n(\sigma) $:
 \[ \sum_{i<j} \sigma_i \sigma_j = \frac{1}{2} \sum_{i \neq j} \sigma_i \sigma_j = \sum_{i,j} \sigma_i \sigma_j -\frac{n}{2} = \frac{n^2 m_n^2(\sigma)}{2} - \frac{n}{2} \]
-da cui, trascurando un'irrilevante costante additiva
-\[ \ham(\sigma) = -\frac{n m_n^2(\sigma)}{2} - hnm_n(\sigma) \]
+da cui
+\begin{equation}
+    \ham(\sigma) = -\frac{n m_n^2(\sigma)}{2} - hnm_n(\sigma) + \frac{1}{2}.
+\end{equation}
 e quindi
-\[ Z_n = \sum_{\sigma \in \Sigma} \exp\left( \frac{\beta n m_n^2(\sigma)}{2} + \beta h n m_n(\sigma) \right) \]
+\begin{equation} \label{eqn:Zn-mag}
+    Z_n = \sum_{\sigma \in \Sigma} \exp\left( \frac{\beta n m_n^2(\sigma)}{2} + \beta h n m_n(\sigma) - \frac{\beta}{2}\right).
+\end{equation}
+Di seguito trascureremo la costante $ 1/2 $ nell'hamiltoniana e conseguentemente a $ -\beta/2 $ a esponente in $ Z_n $ in quanto essa, non dipendendo da $ \sigma $, porta a una costante $ e^{-\beta/2} $ che moltiplica la somma nella \eqref{eqn:Zn-mag} ovvero a un termine del tipo $ -\frac{\beta}{2n} $ in $ \frac{\log Z_n}{n} $, trascurabile nel limite termodinamico.
 
 \subsection{Esistenza del limite}
 Dimostriamo innanzi tutto che il limite $ \lim_{n\to\infty} \frac{\log Z_n}{n} $ esiste.
 \begin{proof}
-    Procediamo facendo vedere che la successione $ \log Z_n $ è subadditiva e usiamo il lemma \ref{lem:fekete}.
-    Posto $ n = n_1 + n_2 $, siano $ \sigma_1 \in \{-1,1\}^{n_1} $ e $ \sigma_2 \in \{-1,1\}^{n_2} $; si ha
-    \[ m_n(\sigma_1,\sigma_2) = \frac{n_1}{n} m_1(\sigma_1) + \frac{n_2}{n} m_2(\sigma_2) \]
-    si verifica con facili calcoli che
+    Procediamo facendo vedere che la successione $ \log Z_n $ è subadditiva e per concludere con il lemma di Fekete (lemma \ref{lem:fekete}).
+    Posto $ n = n_1 + n_2 $, siano $ \sigma_1 \in \{-1,1\}^{n_1} $ e $ \sigma_2 \in \{-1,1\}^{n_2} $ così che $ (\sigma_1, \sigma_2) \in \Sigma $; si ha
+    \[ m_n(\sigma_1,\sigma_2) = \mean{\frac{1}{n} \sum_{i=1}^{n_1} \sigma_i} + \mean{\frac{1}{n} \sum_{i=n_1 + 1}^{n_2} \sigma_i} = \frac{n_1}{n} m_1(\sigma_1) + \frac{n_2}{n} m_2(\sigma_2) \]
+    dove abbiamo definito $ m_1(\sigma) = \frac{1}{n_1} \sum_{i=1}^{n_1}\sigma_{1, i} $ e similmente $ m_2(\sigma) $. Si verifica con facili calcoli che
     \[ n m_n^2 = n_1 m_1^2 + n_2 m_2^2 - \frac{n_1 n_2}{n} (m_1-m_2)^2 \leq n_1 m_1^2 + n_2 m_2^2 \]
     e quindi
     \begin{align*}
@@ -39,20 +48,27 @@ Dimostriamo innanzi tutto che il limite $ \lim_{n\to\infty} \frac{\log Z_n}{n} $
     Prendendo il logaritmo si ottiene $ \log Z_{n_1+n_2} \leq \log Z_{n_1} + \log Z_{n_2} $.
 \end{proof}
 
-Possiamo ora dare una stima grossolana del limite in analisi. \textcolor{red}{(Non ne ho capito il senso)}. In un verso abbiamo:
-\[ Z_n = \sum_{\sigma \in \Sigma} \exp\left( \frac{\beta n m_n^2(\sigma)}{2} + \beta h n m_n(\sigma) \right) \leq \sum_{\sigma \in \Sigma} \exp\left(  \frac{\beta n}{2} + \beta n h \right) = \exp\left( n \left( \log 2 + \frac{\beta}{2} + \beta h \right) \right) \]
+Possiamo ora dare una stima grossolana del limite in analisi. \textcolor{red}{(Non ne ho capito il senso)}. Osservando che dalla definizione $ m_n(\sigma) \leq 1 $, in un verso abbiamo:
+\begin{align*}
+    Z_n & = \sum_{\sigma \in \Sigma} \exp\left( \frac{\beta n m_n^2(\sigma)}{2} + \beta h n m_n(\sigma) \right) \leq \sum_{\sigma \in \Sigma} \exp\left(  \frac{\beta n}{2} + \beta n h \right) \\
+    & = 2^n \exp\left( \frac{\beta n}{2} + \beta n h\right) = \exp\left( n \left( \log 2 + \frac{\beta}{2} + \beta h \right) \right)
+\end{align*}
 Da cui
 \[ \frac{\log Z_n}{n} \leq \log 2 + \frac{\beta}{2} + \beta h \]
-Nell'altro verso, detta $ U $ la distribuzione uniforme sulle $ 2^n $ configurazioni possibili, e usando la diseguaglianza di Jensen, si ha
-\[ Z_n = 2^n \mean{\exp\left(-\beta\ham_n\right)}_U \geq 2^n \exp\left( -\beta \mean{\ham}_U \right) = 2^n \]
-in quanto $ \mean{\sigma_i}_U = 0 $ e $ \mean{\sigma_i\sigma_j}_U = \mean{\sigma_i}_U\mean{\sigma_j}_U = 0 $. Prendendo il logaritmo abbiamo infine:
-\[ \frac{\log Z_n}{n} \geq \log 2 \]
-\textcolor{red}{Abbiamo usato il principio variazionale di Gibbs???}
+Nell'altro verso, detta $ \Omega_0 $ la distribuzione uniforme sulle $ 2^n $ configurazioni possibili, e usando la diseguaglianza di Jensen\footnote{Sia $ (X, \mathcal{F}, \mu) $ uno spazio di misura. Se $ f \colon X \to \R $ è una variabile aleatoria e $ \varphi \colon \R \to \R $ è una funzione convessa, allora \[\varphi\left(\mathbb{E}\left[f\right]\right) \leq \mathbb{E}\left[\varphi(f)\right].\]}, si ha
+\[
+    Z_n = 2^n \mean{\exp\left(-\beta\ham_n\right)}_{\Omega_0} \geq 2^n \exp\left( -\beta \mean{\ham}_{\Omega_0} \right) = 2^n
+\]
+in quanto $ \mean{\sigma_i}_{\Omega_0} = 0 $ e $ \mean{\sigma_i\sigma_j}_{\Omega_0} = \mean{\sigma_i}_{\Omega_0}\mean{\sigma_j}_{\Omega_0} = 0 $. Prendendo il logaritmo abbiamo infine:
+\[ \frac{\log Z_n}{n} \geq \log 2. \]
+La stessa stima dal basso poteva essere ottenuta usando il principio variazionale di Gibbs (che d'altra parte fa uso della disuguaglianza di Jensen). Infatti sapendo che $ F_\beta \leq G[\Omega_0] $ si ottiene
+\[ \frac{\log Z_n}{n} = -\frac{\beta}{n} F_\beta \geq -\frac{\beta}{n} \left[\mean{H}_{\Omega_0} + \frac{1}{\beta} \sum_{\sigma \in \Sigma} \Omega_0(\sigma) \log{\Omega_0(\sigma)}\right]. \]
+Ora come detto in precedenza $ \mean{H}_{\Omega_0} = 0 $ mentre $ \sum_{\sigma \in \Sigma} \Omega_0(\sigma) \log{\Omega_0(\sigma)} = 2^{n} \frac{1}{2^{n}} (- n \log{2}) $ da cui $ \frac{\log Z_n}{n} \geq -\frac{n}{\beta}\left(-\frac{\beta}{n} \log{2}\right) = \log{2} $
 
 \subsection{Calcolo dell'energia libera}
 Calcoliamo ora in modo esatto l'energia libera nel limite termodinamico.
 \subsubsection{Primo bound}
-Sia $ M \in [-1,1] $. Allora si ha $ \exp\left( -\frac{\beta n (m_n(\sigma) - M)^2}{2} \right) \leq 1 $ e quindi
+Sia $ M \in [-1,1] $. Essendo $ -1 \leq m_n(\sigma) \leq 1 $ si ha $ \exp\left( -\frac{\beta n (m_n(\sigma) - M)^2}{2} \right) \leq 1 $. Quindi
 \begin{align*}
     Z_n & \geq \sum_{\sigma \in \Sigma} \exp\left( \frac{\beta n m_n^2(\sigma)}{2} + \beta h n m_n(\sigma) - \frac{\beta n (m_n(\sigma)-M)^2}{2}\right) \\
         & = \exp\left( -\frac{\beta n M^2}{2} \right) \sum_{\sigma \in \Sigma} \exp\left( (M+h) \beta n m_n(\sigma) \right)                              \\
@@ -63,13 +79,13 @@ Sia $ M \in [-1,1] $. Allora si ha $ \exp\left( -\frac{\beta n (m_n(\sigma) - M)
         & = \exp\left( -\frac{\beta n M^2}{2} \right) 2^n \cosh^n(\beta(M+h)). \\
 \end{align*}
 Abbiamo dunque:
-\[ \frac{\log Z_n}{n} \geq \log 2 + \log\cosh(\beta(M+h)) - \frac{\beta M^2}{2} \eqqcolon \alpha(\beta, h) \]
+\[ \frac{\log Z_n}{n} \geq \log 2 + \log\cosh(\beta(M+h)) - \frac{\beta M^2}{2} \eqqcolon \alpha(M, \beta, h) \]
 Prendendo il limite per $ n\to\infty $ e il $ \sup $ al variare di $ M $ in $ [-1,1] $ otteniamo
 \[ \lim_{n \to +\infty}\frac{\log Z_n}{n} \geq \sup_{M\in[-1,1]} \alpha(M, \beta, h) \eqqcolon \bar{\alpha}(\beta, h) \]
 
 \subsubsection{Secondo bound}
 Osserviamo che $ m_n(\sigma) $ può assumere solamente $ n+1 $ valori: $ \im m_n = \left\{ -1, -1 + \frac{2}{n}, \ldots, 1-\frac{2}{n}, 1 \right\} $. Sia ora $ M \in \im m_n $; abbiamo che
-\[ \sum_{M\in \im m_n} \exp\left( -\frac{\beta(m(\sigma)-M)^2}{2} \right) = 1 + \sum_{\substack{M \in \im m_n \\ M \neq m_n(\sigma)}} \exp\left( -\frac{\beta(m(\sigma)-M)^2}{2} \right) \geq 1 \]
+\[ \sum_{M\in \im m_n} \exp\left( -\frac{\beta(m_n(\sigma)-M)^2}{2} \right) = 1 + \sum_{\substack{M \in \im m_n \\ M \neq m_n(\sigma)}} \exp\left( -\frac{\beta(m_n(\sigma)-M)^2}{2} \right) \geq 1 \]
 e quindi
 \begin{align*}
     Z_n & \leq \sum_{M\in \im m_n} \sum_{\sigma \in \Sigma} \exp\left( \frac{\beta n m_n^2(\sigma)}{2} + \beta h n m_n(\sigma) - \frac{\beta n (m_n(\sigma)-M)^2}{2}\right)     \\
@@ -85,9 +101,9 @@ Studiamo ora i punti stazionari di $ \alpha(M, \beta, h) $ a fissati $ \beta $ e
 \begin{equation}\label{eq:mbar}
     \pd{\alpha}{M} = \beta \left( \tanh(\beta (M+h)) - M \right) = 0.
 \end{equation}
-Nel caso particolare $ h = 0 $, cioè in assenza di campo esterno, l'equazione si riduce a $ \tanh{\beta M} = M $. Questa ha sempre la soluzione $ M = 0 $, mentre solo nel caso $ \beta > 1 $ si aggiungono due soluzioni opposte non nulle. Inoltre in un intorno destro di $ M = 0 $ la derivata $ \pd{\alpha}{M} $ è negativa per $ \beta \leq 1 $, positiva per $ \beta > 1 $. Dunque in $ M = 0 $ $ \alpha $ presenta un massimo per $ \beta \leq 1 $, mentre un minimo per $ \beta > 1 $. Si verifica infine che le soluzioni aggiuntive presenti nel caso $ \beta > 1 $ corrispondono a due massimi (si veda anche la figura \ref{fig:alpha}).
+Nel caso particolare $ h = 0 $, cioè in assenza di campo esterno, l'equazione si riduce a $ \tanh{\beta M} = M $. Questa ha sempre la soluzione $ M = 0 $, mentre solo nel caso $ \beta > 1 $ si aggiungono due soluzioni opposte non nulle. Inoltre in un intorno destro di $ M = 0 $ la derivata $ \pd{\alpha}{M} $ è negativa per $ \beta \leq 1 $, positiva per $ \beta > 1 $. Dunque in $ M = 0 $ $ \alpha $ presenta un massimo per $ \beta \leq 1 $, mentre un minimo per $ \beta > 1 $. Si verifica infine che le soluzioni aggiuntive presenti nel caso $ \beta > 1 $ corrispondono a due massimi (si veda anche la Figura \ref{fig:alpha}).
 
-Nel seguito porremo $ \bar{M}(\beta,h) \coloneqq \argmax_{M\in[-1,1]} \alpha(M,\beta,h) $ e dunque sarà $ \bar{\alpha}(\beta, h) = \alpha(\bar{M}, \beta, h) $\footnote{In caso di ambiguità si scelga, ad esempio, il più grande $ M $ che realizzano il massimo.}. Nella figura \ref{fig:transizione} è riportato l'andamento di $ \pm \bar{M}(\beta, 0) $ in funzione di $ T=\frac{1}{\beta} $. Si osserva che in corrispondenza di $ \beta = 1 $ il sistema presenza una transizione di fase \textcolor{red}{di seconda specie}.
+Nel seguito porremo $ \overline{M}(\beta,h) \coloneqq \argmax_{M\in[-1,1]} \alpha(M,\beta,h) $ e dunque sarà $ \bar{\alpha}(\beta, h) = \alpha(\overline{M}, \beta, h) $\footnote{In caso di ambiguità si scelga, ad esempio, il più grande $ M $ che realizzano il massimo.}. Nella Figura \ref{fig:transizione} è riportato l'andamento di $ \pm \overline{M}(\beta, 0) $ in funzione di $ T=\frac{1}{\beta} $. Si osserva che in corrispondenza di $ \beta = 1 $ il sistema presenza una transizione di fase \textcolor{red}{di seconda specie}.
 
 \iffigureon
 \begin{figure}[p]
@@ -102,7 +118,7 @@ Nel seguito porremo $ \bar{M}(\beta,h) \coloneqq \argmax_{M\in[-1,1]} \alpha(M,\
 \begin{figure}[p]
     \centering
     \includegraphics[scale=0.8]{img/cw/transizione.pdf}
-    \caption{$ \bar{M} $ in funzione di $ T = \frac{1}{\beta}$.}
+    \caption{$ \overline{M} $ in funzione di $ T = \frac{1}{\beta}$.}
     \label{fig:transizione}
 \end{figure}
 \fi
@@ -129,16 +145,15 @@ Abbiamo quindi
 \begin{align}
 	\label{eq:limmagnmedia}
     \lim_{n \to +\infty}\mean{m_n}_{P_\beta} & = \frac{1}{\beta} \lim_{n \to +\infty} \dpd{}{h}\left(\frac{\log Z_n}{n}\right) = \frac{1}{\beta} \dpd{}{h} \left( \lim_{n \to +\infty} \frac{\log Z_n}{n} \right) \nonumber \\
-	                                         & = \frac{1}{\beta} \dpd{\bar{\alpha}}{h}(\beta, h) = \frac{1}{\beta} \dpd{\alpha}{h} (\bar{M}, \beta, h) = \tanh(\beta(\bar{M}+h)) = \bar{M}(\beta, h)
+	                                         & = \frac{1}{\beta} \dpd{\bar{\alpha}}{h}(\beta, h) = \frac{1}{\beta} \dpd{\alpha}{h} (\overline{M}, \beta, h) = \tanh(\beta(\overline{M}+h)) = \overline{M}(\beta, h)
 \end{align}
 dove si è sostituita la condizione \eqref{eq:mbar} e si sono scambiati limite e derivata per la proposizione \ref{prop:convessascambio}. Nel caso $ h = 0 $ abbiamo inoltre
 \[ \pd{}{\beta} \left(\frac{\log Z_n}{n}\right) = \frac{1}{n Z_n} \pd{Z_n}{\beta} = \frac{1}{n Z_n} \sum_{\sigma \in \Sigma} \exp\left( \frac{\beta n m_n^2(\sigma)}{2} \right) \frac{n m_n^2(\sigma)}{2} = \frac{1}{2} \mean{m_n^2}_{P_\beta} \]
 da cui
 \begin{align*}
 	\lim_{n \to +\infty}\mean{m_n^2}_{P_\beta} & = 2 \lim_{n \to +\infty} \dpd{}{\beta} \left(\frac{\log Z_n}{n}\right) = 2 \dpd{}{\beta} \left( \lim_{n \to +\infty}\frac{\log Z_n}{n} \right) \\
-                                               & =	2 \dpd{\bar{\alpha}}{\beta}(\beta,0) = 2\dpd{\alpha}{\beta}(\bar{M},\beta,0) = 2\left( \bar{M}\tanh(\beta\bar{M}) - \frac{\bar{M}^2}{2} \right) = \bar{M}^2.
+                                               & =	2 \dpd{\bar{\alpha}}{\beta}(\beta,0) = 2\dpd{\alpha}{\beta}(\overline{M},\beta,0) = 2\left( \overline{M}\tanh(\beta\overline{M}) - \frac{\overline{M}^2}{2} \right) = \overline{M}^2.
 \end{align*}
 Dalla \eqref{eq:limmagnmedia} segue che $ \mean{m_n}_{P_\beta} = 0 $ se $ h = 0 $ e $ \beta \leq 1 $.
 
 \textcolor{red}{Qui mancano un po' di discorsi conclusivi che però vengono ripresi nella lezione successiva.}
-


### PR DESCRIPTION
Oltre ai typo ho aggiunto qualche frase in più per chiarire certe affermazioni. In più ho messo dei numeri a delle equazioni e ho sostituito ``\bar{U}``  e ``\overline{U}`` e similmente per ``M`` perché il ``\bar`` non si vede.